### PR TITLE
Multi now uses TCP for all requests.

### DIFF
--- a/src/autoloads/MultiImplementation.gd
+++ b/src/autoloads/MultiImplementation.gd
@@ -20,6 +20,8 @@ func _ready() -> void :
 	#warning-ignore:return_value_discarded
 	get_tree().connect("server_disconnected", self, "server_disconnected")
 
+	connection.set_transfer_mode( 2 ) 
+
 
 func connect_to_server( ip4_address : String ) -> bool :
 	#Connect to another player.


### PR DESCRIPTION
As the name suggests. I don't have too much experience with setting Godot Networking API up as TCP.

 What I did was make the connection ( a NetworkedMultiplayerENet ) have a transfer mode of two.

As so: 
var connection = NetworkedMultiplayerENet.new()
connection.set_transfer_mode( 2 ) 

Obviously I use connection to establish the connection between the host player and the joining player.